### PR TITLE
Parameterized block and target goal locations

### DIFF
--- a/tdmpc2/config.yaml
+++ b/tdmpc2/config.yaml
@@ -10,13 +10,14 @@ episode_length_s : 5
 init_joint_angles: [6.9761, 1.1129, 1.7474, -2.2817, 7.5884, -1.1489, 1.6530, 0.8213, 0.8200, 0.8209, 0.8208, 0.8217, 0.8210]
 init_quat: [0, 0, 0, 1]
 bracelet_link_height: 0.25
-init_box_pos: [0.2, 0.2, 0.002]
+init_box_pos: [0.2, 0.2]
+box_gen_range: [0.1, 0.1]
 box_size: [0.08, 0.08, 0.02]
 termination_if_cube_goal_dist_less_than: 0.01
 cube_goal_dist_rew_scale: 10
 cube_arm_dist_rew_scale: 10
 success_reward: 1
-target_displacement: 0.3
+target_pos: [0.3, 0.]
 action_scale: 0.5
 
 # evaluation

--- a/tdmpc2/envs/__init__.py
+++ b/tdmpc2/envs/__init__.py
@@ -91,7 +91,7 @@ def make_env(cfg):
 		render_mode="rgb_array", 
 		max_episode_steps=50, 
 		control_mode="pd_ee_delta_pose",
-		kwargs=kwargs
+		**kwargs
 	)
 
 	env = ScaleAction(env, scale_factor=cfg.action_scale)  # Scale down the action space

--- a/tdmpc2/envs/__init__.py
+++ b/tdmpc2/envs/__init__.py
@@ -77,7 +77,23 @@ def make_env(cfg):
 	"""
 	Make kinova environment for TD-MPC2 experiments.
 	"""
-	env = gym.make("KinovaPushCube", num_envs=cfg.num_envs, render_mode="rgb_array", max_episode_steps=50, control_mode="pd_ee_delta_pose")
+	# Init kwargs dict
+	kwargs = {
+		"block_offset": cfg.init_box_pos,
+		"block_gen_range": cfg.box_gen_range,
+		"target_offset": cfg.target_pos,
+		"goal_radius": cfg.termination_if_cube_goal_dist_less_than,
+	}
+
+	env = gym.make(
+		"KinovaPushCube",
+		num_envs=cfg.num_envs,
+		render_mode="rgb_array", 
+		max_episode_steps=50, 
+		control_mode="pd_ee_delta_pose",
+		kwargs=kwargs
+	)
+
 	env = ScaleAction(env, scale_factor=cfg.action_scale)  # Scale down the action space
 
 	cfg.obs_shape = {cfg.get('obs', 'state'): (env.observation_space.shape[1], )}

--- a/tdmpc2/test_env.py
+++ b/tdmpc2/test_env.py
@@ -3,6 +3,13 @@ import gymnasium as gym
 import torch
 import time
 
+# Init kwargs dict
+kwargs = {
+    "block_offset": [0.2, 0.2],
+    "block_gen_range": [0.1, 0.1],
+    "target_offset": [0.3, 0.],
+    "goal_radius": 0.1,
+}
 num_envs = 256
 env = gym.make("KinovaPushCube", num_envs=num_envs, control_mode="pd_ee_delta_pose", render_mode="rgb_array")
 env.unwrapped.print_sim_details()

--- a/tdmpc2/test_env.py
+++ b/tdmpc2/test_env.py
@@ -5,13 +5,13 @@ import time
 
 # Init kwargs dict
 kwargs = {
-    "block_offset": [0.2, 0.2],
+    "block_offset": [0.1, 0.1],
     "block_gen_range": [0.1, 0.1],
     "target_offset": [0.3, 0.],
     "goal_radius": 0.1,
 }
 num_envs = 256
-env = gym.make("KinovaPushCube", num_envs=num_envs, control_mode="pd_ee_delta_pose", render_mode="rgb_array")
+env = gym.make("KinovaPushCube", num_envs=num_envs, control_mode="pd_ee_delta_pose", render_mode="rgb_array", **kwargs)
 env.unwrapped.print_sim_details()
 obs, _ = env.reset(seed=0)
 done = False


### PR DESCRIPTION
### Summary
The updates in this PR introduce some minor changes to pass in kwargs to the env. These arguments are used to control the following:
1. Position of the block (in 2D only)
2. Block generation range (in 2D -- i.e. can individually control length and width of the generation region)
3. Position of the target position

This should allow for better control of the environment setup. Specifically enabling the desired sideways push setup, with hardcoding that specific setup.

Tested this locally with the test_env.py script (with a single env)

### Concerns:
Need to be able to move the camera to show arm + block + target. 
- No camera changes were added as part of these changes 😞 