### PR TITLE
Stacked Observations

### DIFF
--- a/tdmpc2/config.yaml
+++ b/tdmpc2/config.yaml
@@ -6,6 +6,7 @@ task: kinova_sweep
 obs: state
 episodic: false
 num_envs: 64
+obs_buffer_size: 3
 init_box_pos: [-0.3, 0.2]
 box_gen_range: [0.1, 0.1]
 box_size: [0.08, 0.08, 0.02]

--- a/tdmpc2/envs/__init__.py
+++ b/tdmpc2/envs/__init__.py
@@ -5,6 +5,7 @@ import gymnasium as gym
 
 from envs.wrappers.multitask import MultitaskWrapper
 from envs.wrappers.tensor import TensorWrapper
+from envs.wrappers.frame_stack import FrameStack
 
 def missing_dependencies(task):
 	raise ValueError(f'Missing dependencies for task {task}; install dependencies to use this environment.')
@@ -100,7 +101,7 @@ def make_env(cfg):
 	)
 
 	env = ScaleAction(env, scale_factor=cfg.action_scale)  # Scale down the action space
-
+	env = FrameStack(env, num_stack=cfg.obs_buffer_size)
 	cfg.obs_shape = {cfg.get('obs', 'state'): (env.observation_space.shape[1], )}
 	cfg.action_dim = env.action_space.shape[1]
 	cfg.episode_length = 50 # manually set in KinovaPushCubeEnv

--- a/tdmpc2/envs/wrappers/frame_stack.py
+++ b/tdmpc2/envs/wrappers/frame_stack.py
@@ -85,8 +85,8 @@ class LazyFrames:
         """
         if isinstance(int_or_slice, int):
             return self._check_decompress(self._frames[int_or_slice])  # single frame
-        return torch.stack(
-            [self._check_decompress(f) for f in self._frames[int_or_slice]], axis=0
+        return torch.concatenate(
+            [self._check_decompress(f) for f in self._frames[int_or_slice]], dim=-1
         )
 
     def __eq__(self, other):

--- a/tdmpc2/envs/wrappers/frame_stack.py
+++ b/tdmpc2/envs/wrappers/frame_stack.py
@@ -171,7 +171,7 @@ class FrameStack(gym.ObservationWrapper, gym.utils.RecordConstructorArgs):
             :class:`LazyFrames` object for the wrapper's frame buffer,  :attr:`self.frames`
         """
         assert len(self.frames) == self.num_stack, (len(self.frames), self.num_stack)
-        return LazyFrames(list(self.frames), self.lz4_compress)
+        return LazyFrames(list(self.frames), self.lz4_compress)[:]
 
     def step(self, action):
         """Steps through the environment, appending the observation to the frame buffer.

--- a/tdmpc2/envs/wrappers/frame_stack.py
+++ b/tdmpc2/envs/wrappers/frame_stack.py
@@ -1,0 +1,202 @@
+"""
+DISCLAIMER: This was pulled from the gymnasium library and modified to support torch tensors.
+Otherwise would get errors.
+"""
+
+"""Wrapper that stacks frames."""
+from collections import deque
+from typing import Union
+
+import torch
+import numpy as np
+
+import gymnasium as gym
+from gymnasium.error import DependencyNotInstalled
+from gymnasium.spaces import Box
+
+
+class LazyFrames:
+    """Ensures common frames are only stored once to optimize memory use.
+
+    To further reduce the memory use, it is optionally to turn on lz4 to compress the observations.
+
+    Note:
+        This object should only be converted to numpy array just before forward pass.
+    """
+
+    __slots__ = ("frame_shape", "dtype", "shape", "lz4_compress", "_frames")
+
+    def __init__(self, frames: list, lz4_compress: bool = False):
+        """Lazyframe for a set of frames and if to apply lz4.
+
+        Args:
+            frames (list): The frames to convert to lazy frames
+            lz4_compress (bool): Use lz4 to compress the frames internally
+
+        Raises:
+            DependencyNotInstalled: lz4 is not installed
+        """
+        self.frame_shape = tuple(frames[0].shape)
+        self.shape = (len(frames),) + self.frame_shape
+        self.dtype = frames[0].dtype
+        if lz4_compress:
+            try:
+                from lz4.block import compress
+            except ImportError as e:
+                raise DependencyNotInstalled(
+                    "lz4 is not installed, run `pip install gymnasium[other]`"
+                ) from e
+
+            frames = [compress(frame) for frame in frames]
+        self._frames = frames
+        self.lz4_compress = lz4_compress
+
+    def __array__(self, dtype=None):
+        """Gets a numpy array of stacked frames with specific dtype.
+
+        Args:
+            dtype: The dtype of the stacked frames
+
+        Returns:
+            The array of stacked frames with dtype
+        """
+        arr = self[:]
+        if dtype is not None:
+            return arr.astype(dtype)
+        return arr
+
+    def __len__(self):
+        """Returns the number of frame stacks.
+
+        Returns:
+            The number of frame stacks
+        """
+        return self.shape[0]
+
+    def __getitem__(self, int_or_slice: Union[int, slice]):
+        """Gets the stacked frames for a particular index or slice.
+
+        Args:
+            int_or_slice: Index or slice to get items for
+
+        Returns:
+            torch.stacked frames for the int or slice
+
+        """
+        if isinstance(int_or_slice, int):
+            return self._check_decompress(self._frames[int_or_slice])  # single frame
+        return torch.stack(
+            [self._check_decompress(f) for f in self._frames[int_or_slice]], axis=0
+        )
+
+    def __eq__(self, other):
+        """Checks that the current frames are equal to the other object."""
+        return self.__array__() == other
+
+    def _check_decompress(self, frame):
+        if self.lz4_compress:
+            from lz4.block import decompress
+
+            return torch.frombuffer(decompress(frame), dtype=self.dtype).reshape(
+                self.frame_shape
+            )
+        return frame
+
+
+class FrameStack(gym.ObservationWrapper, gym.utils.RecordConstructorArgs):
+    """Observation wrapper that stacks the observations in a rolling manner.
+
+    For example, if the number of stacks is 4, then the returned observation contains
+    the most recent 4 observations. For environment 'Pendulum-v1', the original observation
+    is an array with shape [3], so if we stack 4 observations, the processed observation
+    has shape [4, 3].
+
+    Note:
+        - To be memory efficient, the stacked observations are wrapped by :class:`LazyFrame`.
+        - The observation space must be :class:`Box` type. If one uses :class:`Dict`
+          as observation space, it should apply :class:`FlattenObservation` wrapper first.
+        - After :meth:`reset` is called, the frame buffer will be filled with the initial observation.
+          I.e. the observation returned by :meth:`reset` will consist of `num_stack` many identical frames.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> from gymnasium.wrappers import FrameStack
+        >>> env = gym.make("CarRacing-v2")
+        >>> env = FrameStack(env, 4)
+        >>> env.observation_space
+        Box(0, 255, (4, 96, 96, 3), uint8)
+        >>> obs, _ = env.reset()
+        >>> obs.shape
+        (4, 96, 96, 3)
+    """
+
+    def __init__(
+        self,
+        env: gym.Env,
+        num_stack: int,
+        lz4_compress: bool = False,
+    ):
+        """Observation wrapper that stacks the observations in a rolling manner.
+
+        Args:
+            env (Env): The environment to apply the wrapper
+            num_stack (int): The number of frames to stack
+            lz4_compress (bool): Use lz4 to compress the frames internally
+        """
+        gym.utils.RecordConstructorArgs.__init__(
+            self, num_stack=num_stack, lz4_compress=lz4_compress
+        )
+        gym.ObservationWrapper.__init__(self, env)
+
+        self.num_stack = num_stack
+        self.lz4_compress = lz4_compress
+
+        self.frames = deque(maxlen=num_stack)
+
+        low = np.repeat(self.observation_space.low[np.newaxis, ...], num_stack, axis=0)
+        high = np.repeat(
+            self.observation_space.high[np.newaxis, ...], num_stack, axis=0
+        )
+        self.observation_space = Box(
+            low=low, high=high, dtype=self.observation_space.dtype
+        )
+
+    def observation(self, observation):
+        """Converts the wrappers current frames to lazy frames.
+
+        Args:
+            observation: Ignored
+
+        Returns:
+            :class:`LazyFrames` object for the wrapper's frame buffer,  :attr:`self.frames`
+        """
+        assert len(self.frames) == self.num_stack, (len(self.frames), self.num_stack)
+        return LazyFrames(list(self.frames), self.lz4_compress)
+
+    def step(self, action):
+        """Steps through the environment, appending the observation to the frame buffer.
+
+        Args:
+            action: The action to step through the environment with
+
+        Returns:
+            Stacked observations, reward, terminated, truncated, and information from the environment
+        """
+        observation, reward, terminated, truncated, info = self.env.step(action)
+        self.frames.append(observation)
+        return self.observation(None), reward, terminated, truncated, info
+
+    def reset(self, **kwargs):
+        """Reset the environment with kwargs.
+
+        Args:
+            **kwargs: The kwargs for the environment reset
+
+        Returns:
+            The stacked observations
+        """
+        obs, info = self.env.reset(**kwargs)
+
+        [self.frames.append(obs) for _ in range(self.num_stack)]
+
+        return self.observation(None), info

--- a/tdmpc2/envs/wrappers/frame_stack.py
+++ b/tdmpc2/envs/wrappers/frame_stack.py
@@ -153,9 +153,9 @@ class FrameStack(gym.ObservationWrapper, gym.utils.RecordConstructorArgs):
 
         self.frames = deque(maxlen=num_stack)
 
-        low = np.repeat(self.observation_space.low[np.newaxis, ...], num_stack, axis=0)
+        low = np.repeat(self.observation_space.low[...], num_stack, axis=1)
         high = np.repeat(
-            self.observation_space.high[np.newaxis, ...], num_stack, axis=0
+            self.observation_space.high[...], num_stack, axis=1
         )
         self.observation_space = Box(
             low=low, high=high, dtype=self.observation_space.dtype

--- a/tdmpc2/envs/wrappers/multitask.py
+++ b/tdmpc2/envs/wrappers/multitask.py
@@ -43,7 +43,8 @@ class MultitaskWrapper(gym.Wrapper):
 
 	def _pad_obs(self, obs):
 		if obs.shape != self._obs_shape:
-			obs = torch.cat((obs, torch.zeros(self._obs_shape[0]-obs.shape[0], dtype=obs.dtype, device=obs.device)))
+			# Should have self.env defined if this is called.
+			obs = torch.cat((obs, torch.zeros(self._obs_shape[0]-obs.shape[0], dtype=obs.dtype, device=self.env.get_wrapper_attr('device'))))
 		return obs
 	
 	def reset(self, task_idx=-1):

--- a/tdmpc2/test_env.py
+++ b/tdmpc2/test_env.py
@@ -1,4 +1,5 @@
 from envs.kinova_env import KinovaPushCubeEnv
+from envs.wrappers.frame_stack import FrameStack
 from envs import ScaleAction
 import gymnasium as gym
 import torch
@@ -15,6 +16,7 @@ kwargs = {
 num_envs = 2
 env = ScaleAction(gym.make("KinovaPushCube", num_envs=num_envs, control_mode="pd_ee_delta_pose", render_mode="rgb_array", **kwargs), scale_factor=0.2)
 env.unwrapped.print_sim_details()
+env = FrameStack(env, 3) 
 obs, _ = env.reset(seed=0)
 done = False
 start_time = time.time()
@@ -22,7 +24,7 @@ total_rew = 0
 frames = []
 while not done:
     # note that env.action_space is now a batched action space
-    obs, rew, terminated, truncated, info = env.step(torch.from_numpy(env.action_space.sample()).to(device=obs.device))
+    obs, rew, terminated, truncated, info = env.step(torch.from_numpy(env.action_space.sample()).to(device=env.get_wrapper_attr('device')))
     done = (terminated | truncated).any() # stop if any environment terminates/truncates
 N = num_envs * info["elapsed_steps"][0].item()
 dt = time.time() - start_time
@@ -39,7 +41,7 @@ total_rew = 0
 frames = []
 while not done:
     # note that env.action_space is now a batched action space
-    obs, rew, terminated, truncated, info = env.step(torch.from_numpy(env.action_space.sample()).to(device=obs.device))
+    obs, rew, terminated, truncated, info = env.step(torch.from_numpy(env.action_space.sample()).to(device=env.get_wrapper_attr('device')))
     frame = env.render()
     frames.append(frame)
     done = (terminated | truncated).any() # stop if any environment terminates/truncates

--- a/tdmpc2/trainer/online_trainer.py
+++ b/tdmpc2/trainer/online_trainer.py
@@ -31,7 +31,7 @@ class OnlineTrainer(Trainer):
 		for i in range(self.cfg.eval_episodes // self.cfg.num_envs):
 			obs, _ = self.env.reset()
 			done = torch.tensor(False)
-			ep_reward = torch.zeros(self.cfg.num_envs, device=obs.device)
+			ep_reward = torch.zeros(self.cfg.num_envs, device=self.env.get_wrapper_attr('device'))
 			t = 0
 			if self.cfg.save_video:
 				self.logger.video.init(self.env, enabled=(i==0))


### PR DESCRIPTION
Using [FrameStack](https://gymnasium.farama.org/v0.29.0/_modules/gymnasium/wrappers/frame_stack/) observation wrapper from the gym library (technically). So far I've only tested it with the test_env script and had to make a modified copy of the wrapper that works with torch. 

It inherently uses numpy arrays, so I was getting errors related to the `device`.

It also returns a `LazyFrame` object by default instead of a tensor for the obs. We can get the underlying obs by just calling the __get_item__ method, but I just have it returning the stacked tensor always (unless we don't want to do that,  seems to use lz4 compression otherwise :eyes:).

^^^ on that note, before having it return tensors, I had to update any `obs.device` to `env.get_wrapper_attr('device')`. I've left it as is incase for now incase we want to just use the `LazyFrame` object, but I can revert those if needed.

Started a slurm job to test this out with training (i suspect there might be a few things to clean up), but atm have to go afk so putting this PR up as well (will undraft after training results)
