### PR TITLE
Domain Randomization 

### DIFF
--- a/tdmpc2/config.yaml
+++ b/tdmpc2/config.yaml
@@ -5,25 +5,29 @@ defaults:
 task: kinova_push_cube
 obs: state
 episodic: false
-num_envs: 64
+num_envs: 128
 obs_buffer_size: 10
 init_box_pos: [-0.3, 0.2]
 box_gen_range: [0.1, 0.1]
-box_size: [0.08, 0.08, 0.02]
-termination_if_cube_goal_dist_less_than: 0.1
+termination_if_cube_goal_dist_less_than: 0.05
 target_pos: [0., 0.2]
-cube_half_sizes: [0.04, 0.04, 0.02]
 action_scale: 0.5
+cube_randomization_ranges:
+    size: [[0.04, 0.04, 0.04], [0.07, 0.07, 0.07]]
+    dynamic_friction: [0.1, 0.3]
+    static_friction: [0.1, 0.3]
+    restitution: [0.1, 0.3]
+    mass: [0.1, 1.0]
 
 # evaluation
 checkpoint: ???
-eval_episodes: 64 # must be multiple of num_envs
+eval_episodes: 128 # must be multiple of num_envs
 eval_freq: 99_968 # must be a multiple of num_envs
 
 # training
-steps: 1_000_000 # should be multiple of num_envs
+steps: 999_936 # should be multiple of num_envs
 batch_size: 512
-steps_per_update: 64 # should be a divisor of num_envs
+steps_per_update: 128 # should be a divisor of num_envs
 reward_coef: 0.1
 value_coef: 0.1
 termination_coef: 1

--- a/tdmpc2/envs/kinova_env.py
+++ b/tdmpc2/envs/kinova_env.py
@@ -16,7 +16,7 @@ def make_env(cfg):
       "block_gen_range": cfg.box_gen_range,
       "target_offset": cfg.target_pos,
       "goal_radius": cfg.termination_if_cube_goal_dist_less_than,
-      "cube_half_sizes": cfg.cube_half_sizes,
+      "cube_randomization_ranges": cfg.cube_randomization_ranges,
     }
 
   env = gym.make(

--- a/tdmpc2/envs/kinova_envs/KinovaPushCubeEnv.py
+++ b/tdmpc2/envs/kinova_envs/KinovaPushCubeEnv.py
@@ -4,10 +4,13 @@ import numpy as np
 import sapien
 import torch
 
+from sapien.physx import PhysxRigidBodyComponent, PhysxRigidBaseComponent
+
 from mani_skill.utils import sapien_utils
 from mani_skill.utils.building import actors
 from mani_skill.sensors.camera import CameraConfig
 from mani_skill.utils.scene_builder.table import TableSceneBuilder
+from mani_skill.utils.structs.actor import Actor
 
 from mani_skill.utils.registration import register_env
 from mani_skill.envs.tasks.tabletop.push_cube import PushCubeEnv
@@ -26,13 +29,19 @@ class KinovaPushCubeEnv(PushCubeEnv):
     self.block_gen_range = kwargs["block_gen_range"]
     self.target_offset = kwargs["target_offset"]
     self.goal_radius = kwargs["goal_radius"]
-    self.cube_half_sizes = kwargs["cube_half_sizes"]
+
+    self.cube_rand_ranges = kwargs["cube_randomization_ranges"]
+    self.cube_size_range = self.cube_rand_ranges["size"]
+    self.dynamic_friction_range = self.cube_rand_ranges["dynamic_friction"]
+    self.static_friction_range = self.cube_rand_ranges["static_friction"]
+    self.restitution_range = self.cube_rand_ranges["restitution"]
+    self.mass_range = self.cube_rand_ranges["mass"]
     
     del kwargs["block_offset"]
     del kwargs["block_gen_range"]
     del kwargs["target_offset"]
     del kwargs["goal_radius"]
-    del kwargs["cube_half_sizes"]
+    del kwargs["cube_randomization_ranges"]
     super().__init__(*args, robot_uids=robot_uids, **kwargs)
 
   def _load_scene(self, options: dict):
@@ -45,14 +54,31 @@ class KinovaPushCubeEnv(PushCubeEnv):
     # we then add the cube that we want to push and give it a color and size using a convenience build_cube function
     # we specify the body_type to be "dynamic" as it should be able to move when touched by other objects / the robot
     # finally we specify an initial pose for the cube so that it doesn't collide with other objects initially
-    self.obj = actors.build_box(
-        self.scene,
-        half_sizes=self.cube_half_sizes,
-        color=np.array([12, 42, 160, 255]) / 255,
-        name="cube",
-        body_type="dynamic",
-        initial_pose=sapien.Pose(p=[0, 0, self.cube_half_sizes[2]]),
-    )
+    max_size, min_size = self.cube_size_range
+    max_size = torch.tensor(max_size)
+    min_size = torch.tensor(min_size)
+
+    objects = []
+    for i in range(self.num_envs):
+      builder = self.scene.create_actor_builder()
+      cube_size = torch.rand(3) * (max_size - min_size) + min_size
+      cube_half_sizes = cube_size/2
+      # ignore the randomization in height
+      cube_half_sizes[2] = self.cube_half_size
+      builder.add_box_collision(half_size=cube_half_sizes)
+      builder.set_scene_idxs([i])
+      builder.add_box_visual(
+        half_size=cube_half_sizes,
+        material=sapien.render.RenderMaterial(
+          base_color=np.array([12, 42, 160, 255]) / 255
+        )
+      )
+      builder.set_initial_pose(sapien.Pose(p=[0, 0, cube_half_sizes[2]]))
+      obj = builder.build(name = f"object_{i}")
+      self.remove_from_state_dict_registry(obj)
+      objects.append(obj)
+    self.obj = Actor.merge(objects, name = "cube")
+    self.add_to_state_dict_registry(self.obj)
 
     # we also add in red/white target to visualize where we want the cube to be pushed to
     # we specify add_collisions=False as we only use this as a visual for videos and do not want it to affect the actual physics
@@ -72,6 +98,29 @@ class KinovaPushCubeEnv(PushCubeEnv):
     # This is useful if you intend to add some visual goal sites as e.g. done in PickCube that aren't actually part of the task
     # and are there just for generating evaluation videos.
     # self._hidden_objects.append(self.goal_region)
+
+    # Randomize object physical and collision properties
+    for i, obj in enumerate(self.obj._objs):
+      # modify the i-th object which is in parallel environment i
+        
+      # modifying physical properties e.g. randomizing mass from 0.1 to 1kg
+      rigid_body_component: PhysxRigidBodyComponent = obj.find_component_by_type(PhysxRigidBodyComponent)
+      if rigid_body_component is not None:
+          # note the use of _batched_episode_rng instead of torch.rand. _batched_episode_rng helps ensure reproducibility in parallel environments.
+          min_mass, max_mass = self.mass_range
+          rigid_body_component.mass = torch.rand(1).item() * (max_mass - min_mass) + min_mass
+      
+      # modifying per collision shape properties such as friction values
+      rigid_base_component: PhysxRigidBaseComponent = obj.find_component_by_type(PhysxRigidBaseComponent)
+      for shape in rigid_base_component.collision_shapes:
+          min_dyn_fric, max_dyn_fric = self.dynamic_friction_range
+          shape.physical_material.dynamic_friction = torch.rand(1).item() * (max_dyn_fric - min_dyn_fric) + min_dyn_fric
+
+          min_static_fric, max_static_fric = self.static_friction_range
+          shape.physical_material.static_friction = torch.rand(1).item() * (max_static_fric - min_static_fric) + min_static_fric
+          
+          min_restitution, max_restitution = self.restitution_range
+          shape.physical_material.restitution = torch.rand(1).item() * (max_restitution - min_restitution) + min_restitution
 
   @property
   def _default_human_render_camera_configs(self):

--- a/tdmpc2/envs/kinova_envs/ScaleAction.py
+++ b/tdmpc2/envs/kinova_envs/ScaleAction.py
@@ -17,11 +17,11 @@ class ScaleAction(gym.ActionWrapper):
 		)
 
 	def action(self, action):
-		x = self.env.agent.tcp_pos[:, 0]
+		x = self.env.unwrapped.agent.tcp_pos[:, 0]
 		action[:, 0] = torch.where(torch.logical_and(self.x_limits[0] < x, x < self.x_limits[1]), action[:, 0], 0)
-		y = self.env.agent.tcp_pos[:, 1]
+		y = self.env.unwrapped.agent.tcp_pos[:, 1]
 		action[:, 1] = torch.where(torch.logical_and(self.y_limits[0] < y, y < self.y_limits[1]), action[:, 1], 0)
-		z = self.env.agent.tcp_pos[:, 2]
+		z = self.env.unwrapped.agent.tcp_pos[:, 2]
 		action[:, 2] = torch.where(torch.logical_and(self.z_limits[0] < z, z < self.z_limits[1]), action[:, 2], 0)
 		if self.gripper_control:
 			action[:, 3:] = 0

--- a/tdmpc2/test_env.py
+++ b/tdmpc2/test_env.py
@@ -11,12 +11,18 @@ kwargs = {
     "block_offset": [-0.3, 0.2],
     "block_gen_range": [0.1, 0.1],
     "target_offset": [0., 0.2],
-    "goal_radius": 0.1,
-    "cube_half_sizes": [0.04, 0.04, 0.02]
+    "goal_radius": 0.05,
+    "cube_randomization_ranges": {
+        "size": ([0.04, 0.04, 0.04], [0.07, 0.07, 0.07]),
+        "dynamic_friction": (0.1, 0.3),
+        "static_friction": (0.1, 0.3),
+        "restitution": (0.1, 0.3),
+        "mass": (0.9, 1.0)
+    }
 }
-render_mode = "human"
-# render_mode = "rgb_array"
-num_envs = 2 if render_mode != "human" else 1
+# render_mode = "human"
+render_mode = "rgb_array"
+num_envs = 128 if render_mode != "human" else 1
 env = ScaleAction(gym.make("KinovaPushCube", num_envs=num_envs, control_mode="pd_ee_delta_pose", render_mode=render_mode, **kwargs), scale_factor=0.2)
 env.unwrapped.print_sim_details()
 env = FrameStack(env, 3) 
@@ -27,7 +33,7 @@ total_rew = 0
 frames = []
 while not done or render_mode == "human":
     # note that env.action_space is now a batched action space
-    if num_envs is 1:
+    if num_envs == 1:
         obs, rew, terminated, truncated, info = env.step(torch.from_numpy(env.action_space.sample()).to(device=env.get_wrapper_attr('device')).unsqueeze(0))
     else:
         obs, rew, terminated, truncated, info = env.step(torch.from_numpy(env.action_space.sample()).to(device=env.get_wrapper_attr('device')))


### PR DESCRIPTION
### Overview
This PR brings in changes to randomize the Kinova push task domain. Particularly randomizing:
1. "Cube" size; not really a cube anymore :P. (**Note:** height is not configurable -- used to determine success + shouldn't affect this specific problem greatly).
2. Weight of the cube. 
3. Friction/ Collision properties
a. Static friction
b. dynamic friction
c. restituion

These changes are entirely inspired by and mimic the work / examples [here](https://maniskill.readthedocs.io/en/latest/user_guide/tutorials/domain_randomization.html).

### How does it randomize the scene ⁉️ 
Sapiens compiles the object's properties ahead of time during the `_load_scene` method. For that reason, it's not possible to change the properties of the "cube" during evaluation. So that really leaves us with two options:
1. Each env has a randomly generated object that uses for the entirty of the training. 
2. Create 'n' objects ahead of time for each env 'k', then during each episode select one of the 'n' available objects at random.

Option 1 is simple but also restricts the number of random objects to the number of envs. Could possibly still lead to overfitting?

Option 2 requires more changes, and likely increases the size of each scene (background unused objects cached / tucked away), but gives us up to n * k random objects to train with so decreases chances of overfitting.

**This PR introduces option 1. Although this means we have less objects to test with, and thus still risk overfitting, it's also a low effort change.**

### Testing
Updated `test_env.py` to reflect changes and that runs. Was also able to confirm it modifies the size of the block.

Additionally, a training run is available on wandb [here](https://wandb.ai/vishalschool1234-university-of-waterloo/RL-Research/runs/zefqns5a?nw=nwusermahussein04). The video(s) attached to this run are associated with the first env, and clearly shows rectangular prisim **(not a cube)** that has extremely low friction.
